### PR TITLE
Fix: Prevent multiple decimal points (fixes #1)

### DIFF
--- a/js/displayController.js
+++ b/js/displayController.js
@@ -19,6 +19,16 @@ const displayController = {
   },
 
   /**
+   * gets the current number
+   * @returns {string} the current number string
+   */
+  getCurrentNumber: function () {
+    const display = this.getValue();
+    const parts = display.split(/[+\-*/]/);
+    return parts[parts.length - 1];
+  },
+
+  /**
    * set display value
    * @param {string} value
    */
@@ -43,7 +53,23 @@ const displayController = {
    * @param {string} input
    */
   appendToDisplay: function (input) {
+    
+    // checks for MOTD
     if (this.isShowingMotd()) this.clearDisplay();
+
+    // special handling for decimal
+    if (input === '.') {
+      const currentNumber = this.getCurrentNumber();
+      
+      // if num already has . return
+      if (currentNumber.includes('.')) {
+        return;
+
+      // if num is empty add 0 to the front
+      } else if (currentNumber === '') {
+        input = '0.'
+      }
+    }
     this.setValue(this.getValue() + input);
   },
 


### PR DESCRIPTION
Closes #1

## Problem
Users could input multiple decimal points in a single number (e.g., 1.2.3.4), creating invalid expressions that fail to calculate.

## Root Cause
The `appendToDisplay()` function accepted any input without validation, affecting both keyboard and button inputs.

## Solution
- Added `getCurrentNumber()` helper method to extract the current number being typed
- Added decimal validation in `appendToDisplay()` to prevent multiple decimals in the same number
- Bonus: Auto-adds leading zero when decimal starts a number (.5 → 0.5)

## Testing
- [x] Cannot type multiple decimals in same number (1.2.3 stops at 1.2)
- [x] Can type decimals in different numbers (1.2+3.4 works)
- [x] Can start number with decimal (.5 becomes 0.5)
- [x] Can type decimal after operator (5+. becomes 5+0.)
- [x] Works with both keyboard and button inputs
- [x] Existing functionality unchanged