### PR TITLE
Fix: Handle leading decimals in calculator engine (fixes #3)

### DIFF
--- a/js/calculatorEngine.js
+++ b/js/calculatorEngine.js
@@ -10,7 +10,7 @@ const calculatorEngine = {
    * @returns {string} Expression in postfix notation
    */
   infixToPostfix: function (infix) {
-    const tokens = infix.match(/(\d+\.?\d*|[+\-*/()])/g) || [];
+    const tokens = infix.match(/(\d*\.?\d+|[+\-*/()])/g) || [];
     const output = [];
     const operators = [];
 


### PR DESCRIPTION
Closes #3

## Problem
The calculator engine incorrectly evaluates expressions with leading decimals. For example, `.1+.1` evaluates to `2` instead of `0.2`.

## Root Cause
The regex tokenizer in `infixToPostfix()` required at least one digit before the decimal point:
```javascript
// Old pattern - requires digit before decimal
/(\d+\.?\d*|[+\-*/()])/g
```

This caused `.1` to fail matching as a number token, resulting in incorrect parsing.

## Solution
Updated the regex pattern to handle leading decimals:
```javascript
// New pattern - allows leading decimals
/(\d*\.?\d+|[+\-*/()])/g
```

The pattern now matches:
- `\d*` - Zero or more digits before decimal
- `\.?` - Optional decimal point
- `\d+` - One or more digits (ensures at least one digit exists)

## Changes
- Modified `infixToPostfix()` regex in `calculatorEngine.js`
- Engine now correctly handles expressions like `.1+.1`, `.5*.5`, etc.

## Testing
- [x] `.1+.1` evaluates to `0.2` (was `2`)
- [x] `.5*.5` evaluates to `0.25`
- [x] `1+.5` evaluates to `1.5`
- [x] `.123+.456` evaluates to `0.579`
- [x] Standard expressions still work (`2+3*4 = 14`)
- [x] Edge cases handled (`0.1`, `10.5`, etc.)

## Impact
This fix makes the calculator engine more robust and able to handle valid mathematical expressions independently of the UI layer. While the UX currently adds leading zeros, the engine should be able to process expressions correctly on its own.